### PR TITLE
refactor(claude): replace git checkout with git switch

### DIFF
--- a/dot_claude/commands/commit-push-pr.md
+++ b/dot_claude/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git branch:*), Bash(git checkout:*)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git branch:*), Bash(git switch:*)
 argument-hint: [message]
 description: Create a git commit
 ---
@@ -30,7 +30,7 @@ Before committing, ensure you are on a feature branch (not main/master):
        - `<type>/<ticket-id>-<description>` (e.g., `feature/PROJ-123-add-login`)
      - If no clear pattern exists, default to `feature/<description>` or `fix/<description>`
    - Suggest a branch name following the detected pattern based on the changes
-   - Create and switch to the new branch with `git checkout -b <branch-name>`
+   - Create and switch to the new branch with `git switch -c <branch-name>`
 3. If already on a feature branch, proceed to the next step
 
 ## Step 2: Create Commit


### PR DESCRIPTION
## Summary
- Replace deprecated `git checkout` with modern `git switch` command in Claude command configuration

## Changes
- Update `allowed-tools` in `commit-push-pr.md` to use `Bash(git switch:*)` instead of `Bash(git checkout:*)`
- Change branch creation command from `git checkout -b` to `git switch -c`

## Test Plan
- Run `/commit-push-pr` command and verify it uses `git switch -c` for branch creation
- Confirm the allowed-tools correctly permit `git switch` operations

## Notes
- `git switch` was introduced in Git 2.23 (August 2019) as a more focused alternative to `git checkout` for branch operations
- This change improves clarity by using the purpose-specific command