### PR TITLE
refactor(claude): simplify GPG signing check steps

### DIFF
--- a/dot_claude/commands/commit-push-pr.md
+++ b/dot_claude/commands/commit-push-pr.md
@@ -36,15 +36,11 @@ Before committing, ensure you are on a feature branch (not main/master):
 ## Step 2: Check GPG Signing Configuration
 Before creating a commit, check if GPG signing is configured:
 
-1. Check if `commit.gpgsign` is set to `true`:
-   - Run `git config --get commit.gpgsign`
-   - If `true`, Git will automatically sign commits (no extra flag needed)
-
-2. If `commit.gpgsign` is not `true`, check if a signing key is configured:
+1. If `commit.gpgsign` is not `true`, check if a signing key is configured:
    - Run `git config --get user.signingkey`
    - If a signing key exists, use `git commit -S` to sign the commit
 
-3. If neither is configured, create a normal unsigned commit
+2. If neither is configured, create a normal unsigned commit
 
 ## Step 3: Create Commit
 Create a commit following Conventional Commits format:


### PR DESCRIPTION
## Summary
- Simplify the GPG signing configuration check in commit-push-pr command
- Remove redundant step that checked `commit.gpgsign` separately

## Changes
- Removed step 1 that explicitly checked `commit.gpgsign` config
- Renumbered remaining steps (2 → 1, 3 → 2)
- The logic now directly checks for `user.signingkey` if `commit.gpgsign` is not true

## Test Plan
- Run `/commit-push-pr` command and verify GPG signing still works correctly
- Verify unsigned commits are created when no signing key is configured

## Notes
- The previous implementation had a redundant check since `commit.gpgsign=true` means Git handles signing automatically, so explicitly checking it first was unnecessary