### PR TITLE
fix(zsh): exclude Tailscale SSH from hostname prompt

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -62,8 +62,13 @@ function git_branch_name() {
    PROMPT2=$tmp_prompt2  # セカンダリのプロンプト(コマンドが2行以上の時に表示される)
    RPROMPT=$tmp_rprompt  # 右側のプロンプト
    SPROMPT=$tmp_sprompt  # スペル訂正用プロンプト
-  # SSHログイン時のプロンプト
-   [ -n "${REMOTEHOST}${SSH_CONNECTION}" ] && PROMPT="%{${fg[white]}%}${HOST%%.*} ${PROMPT}";
+  # Show hostname in prompt for SSH sessions (exclude Tailscale SSH 100.64.0.0/10)
+  if [ -n "${REMOTEHOST}${SSH_CONNECTION}" ]; then
+    local _ssh_src="${SSH_CONNECTION%% *}"
+    if [[ ! "$_ssh_src" =~ ^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\. ]]; then
+      PROMPT="%{${fg[white]}%}${HOST%%.*} ${PROMPT}"
+    fi
+  fi
 
    ### Title (user@hostname) ###
    case "${TERM}" in


### PR DESCRIPTION
## Summary
- Fix zsh prompt showing hostname on local machines connected via Tailscale SSH
- Skip hostname display when the SSH source IP falls within Tailscale's CGNAT range (`100.64.0.0/10`)

## Changes
- `.zshrc`: Extend SSH detection logic to check the source IP from `SSH_CONNECTION`. If it falls within the CGNAT range (100.64.x.x–100.127.x.x), skip adding the hostname to the prompt
- Normal SSH connections (outside CGNAT range) and `REMOTEHOST`-based SSH detection continue to work as before

## Test Plan
- `SSH_CONNECTION="100.119.191.120 50196 100.97.109.45 22" zsh` → hostname NOT shown
- `SSH_CONNECTION="192.168.1.1 12345 192.168.1.2 22" zsh` → hostname shown
- CGNAT boundary values (100.64.0.1, 100.127.255.254, 100.63.255.255, 100.128.0.0) are correctly classified
- Local session (no `SSH_CONNECTION`) → hostname NOT shown

## Notes
- Tailscale uses the CGNAT range `100.64.0.0/10` for node addresses
- Regex `^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.` matches 100.64.0.0–100.127.255.255