### PR TITLE
feat: Claude/Codex に signed commit ルールを追加

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -4,3 +4,4 @@
 - github.com の URL で 404 が返された場合は `gh` コマンドでリトライすること（権限の問題の可能性あり）
 - ソースコード編集後は、その言語のフォーマッタを実行すること（Go: `go fmt`, Deno: `deno fmt` 等）
 - テストは必ず書くこと。TDD の Red-Green-Refactor サイクルに従い、まず失敗するテストを書き、通る最小限のコードを書き、リファクタリングする
+- git commit 時はまず `git commit -S` で signed commit を試みること。失敗した場合は `git -c commit.gpgsign=false commit` でフォールバックする

--- a/dot_codex/AGENTS.md
+++ b/dot_codex/AGENTS.md
@@ -4,6 +4,7 @@
 - github.com の URL で 404 が返った場合は `gh` コマンドで再試行する（権限問題の可能性）
 - ソースコード編集後は、その言語のフォーマッタを実行する（Go: `go fmt`、Deno: `deno fmt`）
 - テストは必ず書く。t-wadaの提唱するTDD の Red-Green-Refactor サイクルに従う
+- git commit 時はまず `git commit -S` で signed commit を試みる。失敗した場合は `git -c commit.gpgsign=false commit` でフォールバックする
 - AGENTS.md を新規作成した場合は、必ずユーザーにレビューしてもらってからコミットする
 
 # 口調: ずんだもん


### PR DESCRIPTION
## 概要
- Claude Code (`CLAUDE.md`) と Codex (`AGENTS.md`) の基本設定に、git commit 時に signed commit を試みるルールを追加

## 変更点
- `dot_claude/CLAUDE.md`: `git commit -S` を最初に試み、失敗時は `git -c commit.gpgsign=false commit` でフォールバックする指示を追加
- `dot_codex/AGENTS.md`: 同様の指示を追加

## テスト方法
- Claude Code / Codex でコミット操作を行い、signed commit が試行されることを確認

## 備考
- `dot_claude/commands/commit-push-pr.md` には既に Step 2 として同等の手順が存在しており、今回は基本設定レベルでも統一的に適用されるようにした