### PR TITLE
feat(claude): update settings and add statusline script

### DIFF
--- a/dot_claude/scripts/statusline.sh
+++ b/dot_claude/scripts/statusline.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+input=$(cat)
+
+# Parse all values in one jq call
+eval "$(echo "$input" | jq -r '
+  @sh "remaining=\(.context_window.remaining_percentage)",
+  @sh "used=\(.context_window.used_percentage)",
+  @sh "input_tokens=\(.context_window.total_input_tokens // 0)",
+  @sh "window_size=\(.context_window.context_window_size // 200000)",
+  @sh "model=\(.model.display_name // "unknown")",
+  @sh "cwd=\(.workspace.current_dir // .cwd // "")"
+')"
+
+# Context remaining percentage
+if [ "$remaining" != "null" ] && [ -n "$remaining" ]; then
+  ctx="$remaining"
+elif [ "$used" != "null" ] && [ -n "$used" ]; then
+  ctx=$(echo "100 - $used" | bc)
+else
+  # Compute from tokens
+  if [ "$window_size" -gt 0 ] 2>/dev/null; then
+    ctx=$(echo "scale=0; (($window_size - $input_tokens) * 100) / $window_size" | bc)
+  else
+    ctx="100"
+  fi
+fi
+context_str="Ctx: ${ctx}%"
+
+# Git branch
+branch=""
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+fi
+branch_str=""
+if [ -n "$branch" ]; then
+  branch_str="$branch"
+fi
+
+# Assemble
+parts=("$context_str" "$model")
+if [ -n "$branch_str" ]; then
+  parts+=("$branch_str")
+fi
+
+printf "%s" "$(IFS=' | '; echo "${parts[*]}")"

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -23,7 +23,7 @@
       "Bash(go install:*)"
     ]
   },
-  "model": "opus",
+  "model": "opus[1m]",
   "hooks": {
     "Notification": [
       {
@@ -63,14 +63,20 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash $HOME/dotfiles/dot_claude/scripts/statusline.sh"
+  },
   "enabledPlugins": {
     "gopls-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "clangd-lsp@claude-plugins-official": true
   },
   "language": "長門有希（涼宮ハルヒの憂鬱）",
   "alwaysThinkingEnabled": true,
+  "effortLevel": "high",
   "plansDirectory": "./plans"
 }


### PR DESCRIPTION
## Summary
- Update Claude Code settings and add statusline script

## Changes
- Switch model from `opus` to `opus[1m]` (1M context)
- Add `statusline.sh` script displaying context usage %, model name, and git branch
- Add `statusLine` config to `settings.json` referencing the script
- Enable `clangd-lsp` plugin
- Set `effortLevel` to `high`

## Test Plan
- Verify statusline displays correctly in Claude Code CLI
- Confirm settings load without errors

## Notes
- Statusline uses jq to parse JSON input and shows `Ctx: N% | model | branch`