### PR TITLE
feat(claude): enable showClearContextOnPlanAccept

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -78,5 +78,6 @@
   "language": "長門有希（涼宮ハルヒの憂鬱）",
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
+  "showClearContextOnPlanAccept": true,
   "plansDirectory": "./plans"
 }


### PR DESCRIPTION
## Summary
- Enable `showClearContextOnPlanAccept` in Claude Code settings

## Changes
- Add `"showClearContextOnPlanAccept": true` to `dot_claude/settings.json`

## Test Plan
- Verify that accepting a plan in Claude Code shows the clear context option

## Notes
- N/A