### PR TITLE
feat: setup.shをモジュール分割しreusable workflowを追加

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,0 +1,98 @@
+name: Setup dotfiles
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner to use"
+        type: string
+        default: ubuntu-latest
+        required: false
+      symlinks:
+        description: "Create dotfile symlinks"
+        type: boolean
+        default: true
+        required: false
+      claude:
+        description: "Setup Claude Code configuration"
+        type: boolean
+        default: true
+        required: false
+      codex:
+        description: "Setup Codex configuration"
+        type: boolean
+        default: true
+        required: false
+      nvim:
+        description: "Setup Neovim (dein.vim)"
+        type: boolean
+        default: false
+        required: false
+      homebrew:
+        description: "Install Homebrew"
+        type: boolean
+        default: false
+        required: false
+      go-tools:
+        description: "Install Go tools"
+        type: boolean
+        default: false
+        required: false
+      brewfile:
+        description: "Run brewfile.sh (Homebrew packages)"
+        type: boolean
+        default: false
+        required: false
+      dotfiles-ref:
+        description: "Ref of dotfiles repo to use"
+        type: string
+        default: main
+        required: false
+
+jobs:
+  setup:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: whywaita/dotfiles
+          ref: ${{ inputs.dotfiles-ref }}
+          path: dotfiles
+
+      - name: Setup symlinks
+        if: ${{ inputs.symlinks }}
+        run: ./dotfiles/scripts/setup-symlinks.sh
+
+      - name: Setup Claude Code
+        if: ${{ inputs.claude }}
+        run: ./dotfiles/scripts/setup-claude.sh
+
+      - name: Setup Codex
+        if: ${{ inputs.codex }}
+        run: ./dotfiles/scripts/setup-codex.sh
+
+      - name: Setup Neovim
+        if: ${{ inputs.nvim }}
+        run: ./dotfiles/scripts/setup-nvim.sh
+
+      - name: Install Homebrew
+        if: ${{ inputs.homebrew }}
+        run: ./dotfiles/scripts/setup-homebrew.sh
+
+      - name: Setup Go
+        if: ${{ inputs.go-tools }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      - name: Install Go tools
+        if: ${{ inputs.go-tools }}
+        run: ./dotfiles/scripts/setup-go-tools.sh
+
+      - name: Setup Homebrew (for brewfile)
+        if: ${{ inputs.brewfile }}
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: Run brewfile
+        if: ${{ inputs.brewfile }}
+        run: ./dotfiles/brewfile.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck zsh
       - name: Check shell scripts with shellcheck
-        run: shellcheck setup.sh brewfile.sh dot_claude/scripts/setup.sh tests/setup_claude_test.sh
+        run: shellcheck setup.sh brewfile.sh dot_claude/scripts/setup.sh dot_codex/scripts/setup-codex.sh tests/setup_claude_test.sh scripts/setup-symlinks.sh scripts/setup-claude.sh scripts/setup-codex.sh scripts/setup-nvim.sh scripts/setup-homebrew.sh scripts/setup-go-tools.sh
       - name: Run Claude setup test
         run: ./tests/setup_claude_test.sh
       - name: Check zshrc syntax
@@ -87,9 +87,9 @@ jobs:
       - name: Setup Neovim config
         run: |
           mkdir -p ~/.config/nvim
-          ln -s $PWD/init.vim ~/.config/nvim/init.vim
+          ln -s "$PWD/init.vim" ~/.config/nvim/init.vim
           mkdir -p ~/dotfiles
-          ln -s $PWD/nvim ~/dotfiles/nvim
+          ln -s "$PWD/nvim" ~/dotfiles/nvim
       - name: Install dein.vim and plugins
         run: |
           # dein.vim をインストール
@@ -119,3 +119,23 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@main
       - name: Check Homebrew packages exist
         run: ./brewfile.sh
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Run actionlint
+        run: ./actionlint
+
+  setup-test:
+    uses: ./.github/workflows/setup.yaml
+    with:
+      symlinks: true
+      claude: true
+      codex: true
+      nvim: false
+      homebrew: false
+      go-tools: false
+      brewfile: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -139,3 +139,4 @@ jobs:
       homebrew: false
       go-tools: false
       brewfile: false
+      dotfiles-ref: ${{ github.head_ref || github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # whywaita/dotfiles
 
-[![install test](https://github.com/whywaita/dotfiles/actions/workflows/test.yaml/badge.svg)](https://github.com/whywaita/dotfiles/actions/workflows/test.yaml)
+[![lint and check](https://github.com/whywaita/dotfiles/actions/workflows/test.yaml/badge.svg)](https://github.com/whywaita/dotfiles/actions/workflows/test.yaml)
+[![setup](https://github.com/whywaita/dotfiles/actions/workflows/setup.yaml/badge.svg)](https://github.com/whywaita/dotfiles/actions/workflows/setup.yaml)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,91 @@
 
 [![install test](https://github.com/whywaita/dotfiles/actions/workflows/test.yaml/badge.svg)](https://github.com/whywaita/dotfiles/actions/workflows/test.yaml)
 
-# Usage
+## Usage
 
+### Full Setup
+
+```bash
+cd ${HOME}
+git clone --recursive git@github.com:whywaita/dotfiles.git
+sh dotfiles/setup.sh
 ```
-$ cd ${HOME}
-$ git clone --recursive git@github.com:whywaita/dotfiles.git
-$ sh dotfiles/setup.sh
+
+### Individual Setup
+
+`setup.sh` is a wrapper that runs the following scripts in order. You can run them individually as needed.
+
+| Script | Description |
+|--------|-------------|
+| `scripts/setup-symlinks.sh` | Create dotfile symlinks in `$HOME` |
+| `scripts/setup-claude.sh` | Setup Claude Code configuration |
+| `scripts/setup-codex.sh` | Setup Codex configuration |
+| `scripts/setup-nvim.sh` | Clone dein.vim (Neovim plugin manager) |
+| `scripts/setup-homebrew.sh` | Install Homebrew |
+| `scripts/setup-go-tools.sh` | Install Go tools (git-wt) |
+| `brewfile.sh` | Install Homebrew packages |
+
+```bash
+# Example: setup only symlinks and Claude Code
+./scripts/setup-symlinks.sh
+./scripts/setup-claude.sh
+```
+
+## Reusable Workflow
+
+You can call the dotfiles setup from other repositories via GitHub Actions.
+
+### Basic Usage
+
+```yaml
+jobs:
+  setup:
+    uses: whywaita/dotfiles/.github/workflows/setup.yaml@main
+```
+
+By default, `symlinks`, `claude`, and `codex` are enabled.
+
+### Select Components via Inputs
+
+```yaml
+jobs:
+  setup:
+    uses: whywaita/dotfiles/.github/workflows/setup.yaml@main
+    with:
+      symlinks: true
+      claude: true
+      codex: false
+      nvim: true
+      homebrew: false
+      go-tools: false
+      brewfile: false
+```
+
+### Available Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `runs-on` | string | `ubuntu-latest` | Runner to use (e.g. `macos-latest`) |
+| `symlinks` | boolean | `true` | Create dotfile symlinks |
+| `claude` | boolean | `true` | Setup Claude Code |
+| `codex` | boolean | `true` | Setup Codex |
+| `nvim` | boolean | `false` | Setup Neovim (dein.vim) |
+| `homebrew` | boolean | `false` | Install Homebrew |
+| `go-tools` | boolean | `false` | Install Go tools |
+| `brewfile` | boolean | `false` | Install Homebrew packages |
+| `dotfiles-ref` | string | `main` | Ref of dotfiles repo to use |
+
+### Example: Setup Only Claude Code in CI
+
+```yaml
+name: CI
+on: [push]
+
+jobs:
+  build:
+    uses: whywaita/dotfiles/.github/workflows/setup.yaml@main
+    with:
+      symlinks: false
+      claude: true
+      codex: false
 ```

--- a/scripts/setup-claude.sh
+++ b/scripts/setup-claude.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+"$DOTFILES_DIR/dot_claude/scripts/setup.sh"

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+"$DOTFILES_DIR/dot_codex/scripts/setup-codex.sh"

--- a/scripts/setup-go-tools.sh
+++ b/scripts/setup-go-tools.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "Error: go is not installed" >&2
+  exit 1
+fi
+
+echo "Installing Go tools..."
+go install github.com/k1LoW/git-wt@latest

--- a/scripts/setup-homebrew.sh
+++ b/scripts/setup-homebrew.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+if command -v brew >/dev/null 2>&1; then
+  echo "Skip: Homebrew already installed"
+else
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi

--- a/scripts/setup-nvim.sh
+++ b/scripts/setup-nvim.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+DEIN_DIR="$HOME/.cache/dein/repos/github.com/Shougo/dein.vim"
+if [ -d "$DEIN_DIR/.git" ]; then
+  echo "Skip: dein.vim already cloned"
+else
+  mkdir -p "$HOME/.cache/dein/repos/github.com/Shougo"
+  git clone https://github.com/Shougo/dein.vim.git "$DEIN_DIR"
+fi

--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DOT_FILES=(.zshrc .vim .vimrc .tmux .tmux.conf .gitconfig .gemrc .latexmkrc .screenrc .wezterm.lua)
+
+for file in "${DOT_FILES[@]}"
+do
+  src="$DOTFILES_DIR/$file"
+  dst="$HOME/$file"
+  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
+    echo "Skip: $dst already linked correctly"
+  else
+    ln -sf "$src" "$dst"
+  fi
+done
+
+DOT_CONFIG_DIRS=(mdp)
+
+mkdir -p "$HOME/.config"
+
+for dir in "${DOT_CONFIG_DIRS[@]}"
+do
+  src="$DOTFILES_DIR/$dir"
+  dst="$HOME/.config/$dir"
+  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
+    echo "Skip: $dst already linked correctly"
+  else
+    ln -sf "$src" "$dst"
+  fi
+done

--- a/setup.sh
+++ b/setup.sh
@@ -6,52 +6,11 @@ if [ "${CI:-false}" == "true" ]; then
   set +e
 fi
 
-DOT_FILES=(.zshrc .vim .vimrc .tmux .tmux.conf .gitconfig .gemrc .latexmkrc .screenrc .wezterm.lua)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-for file in "${DOT_FILES[@]}"
-do
-  src="$HOME/dotfiles/$file"
-  dst="$HOME/$file"
-  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
-    echo "Skip: $dst already linked correctly"
-  else
-    ln -sf "$src" "$dst"
-  fi
-done
-
-DOT_CONFIG_DIRS=(mdp)
-
-for dir in "${DOT_CONFIG_DIRS[@]}"
-do
-  src="$HOME/dotfiles/$dir"
-  dst="$HOME/.config/$dir"
-  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
-    echo "Skip: $dst already linked correctly"
-  else
-    ln -sf "$src" "$dst"
-  fi
-done
-
-# Setup Claude Code configuration
-"$HOME"/dotfiles/dot_claude/scripts/setup.sh
-
-# Setup Codex configuration
-"$HOME"/dotfiles/dot_codex/scripts/setup-codex.sh
-
-DEIN_DIR="$HOME/.cache/dein/repos/github.com/Shougo/dein.vim"
-if [ -d "$DEIN_DIR/.git" ]; then
-  echo "Skip: dein.vim already cloned"
-else
-  mkdir -p "$HOME"/.cache/dein/repos/github.com/Shougo
-  git clone https://github.com/Shougo/dein.vim.git "$DEIN_DIR"
-fi
-
-if command -v brew >/dev/null 2>&1; then
-  echo "Skip: Homebrew already installed"
-else
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-fi
-
-# Install Go tools
-echo "Installing Go tools..."
-go install github.com/k1LoW/git-wt@latest
+"$SCRIPT_DIR/scripts/setup-symlinks.sh"
+"$SCRIPT_DIR/scripts/setup-claude.sh"
+"$SCRIPT_DIR/scripts/setup-codex.sh"
+"$SCRIPT_DIR/scripts/setup-nvim.sh"
+"$SCRIPT_DIR/scripts/setup-homebrew.sh"
+"$SCRIPT_DIR/scripts/setup-go-tools.sh"


### PR DESCRIPTION
## 概要
- `setup.sh` を個別のセットアップスクリプトに分割し、保守性を向上
- GitHub Actions reusable workflow を追加し、他リポジトリから dotfiles セットアップを呼び出し可能に
- CI に actionlint と setup-test ジョブを追加

## 変更点

### スクリプト分割 (`scripts/` ディレクトリ新規作成)
- `setup-symlinks.sh` — dotfile と ~/.config の symlink 作成
- `setup-claude.sh` — Claude Code 設定
- `setup-codex.sh` — Codex 設定
- `setup-nvim.sh` — dein.vim clone (Neovim プラグイン管理)
- `setup-homebrew.sh` — Homebrew インストール
- `setup-go-tools.sh` — Go tools インストール (git-wt)

### setup.sh のリファクタ
- 各サブスクリプトを呼ぶ薄いラッパーに変更
- `dirname "$0"` ベースのパス解決に統一（`$HOME/dotfiles` ハードコード排除）

### Reusable Workflow (`.github/workflows/setup.yaml`)
- `workflow_call` で他リポジトリから利用可能
- boolean inputs で各コンポーネントを個別に切り替え可能（`symlinks`, `claude`, `codex`, `nvim`, `homebrew`, `go-tools`, `brewfile`）
- `runs-on` input で runner を選択可能
- `pinact run -u` で action hash を最新版に固定

### test.yaml の更新
- shellcheck 対象に新規スクリプトを追加
- `actionlint` ジョブを新規追加
- `setup-test` ジョブで reusable workflow を検証
- neovim-check の `$PWD` クォート修正

## テスト方法
- `shellcheck scripts/*.sh setup.sh` — 全スクリプト通過済み
- `actionlint` — 全 workflow 通過済み
- CI の `setup-test` ジョブで reusable workflow の動作を確認

## 備考
- `Homebrew/actions/setup-homebrew@main` は pinact で pin 不可のため `@main` のまま