### PR TITLE
ci: add tagpr workflow for automatic semver tagging

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,5 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: Songmu/tagpr@9d0f650553240dab1fa907eca27e3fd5b586e538 # v1.18.1
+        id: tagpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update major version tag
+        if: steps.tagpr.outputs.tag != ''
+        env:
+          TAG: ${{ steps.tagpr.outputs.tag }}
+        run: |
+          MAJOR=$(echo "$TAG" | grep -oE '^v[0-9]+')
+          git tag -f "$MAJOR" "$TAG"
+          git push -f origin "$MAJOR"

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,18 @@
+name: tagpr
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: Songmu/tagpr@9d0f650553240dab1fa907eca27e3fd5b586e538 # v1.18.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,4 @@
+# config file for the tagpr in git config format
+[tagpr]
+	vPrefix = true
+	releaseBranch = main


### PR DESCRIPTION
## Summary
- Songmu/tagpr を使用した自動semverバージョニングworkflowを追加
- mainへのマージ時にリリースPR自動作成・タグ付け・GitHub Release作成を行う

## Changes
- `.github/workflows/tagpr.yml`: mainへのpush時にtagprを実行するworkflow
- `.tagpr`: tagpr設定ファイル（vPrefix有効、releaseBranch=main）

## Test Plan
- [ ] actionlintでworkflowの構文チェック済み
- [ ] マージ後、tagprがリリースPRを自動作成することを確認
- [ ] Settings > Actions > Workflow permissionsが「Read and write」であることを確認

## Notes
- [whywaita/keex](https://github.com/whywaita/keex) のtagpr構成を参考にした
- dotfilesリポジトリのためGoReleaserは不要、tagprのみのシンプルな構成