### PR TITLE
feat(skill): add conflict detection and CI verification to commit-push-pr

### DIFF
--- a/dot_claude/commands/commit-push-pr.md
+++ b/dot_claude/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git branch:*), Bash(git switch:*), Bash(git config:*), Bash(git symbolic-ref refs/remotes/origin/HEAD:*)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git branch:*), Bash(git switch:*), Bash(git config:*), Bash(git symbolic-ref refs/remotes/origin/HEAD:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git log:*), Bash(git diff:*), Bash(gh pr checks:*), Bash(gh run view:*), Bash(gh run watch:*), Bash(gh run list:*)
 argument-hint: [message]
 description: Create a git commit
 ---
@@ -66,12 +66,31 @@ prompt: <user's input prompt>
 - Description: Present tense, lowercase, under 50 chars, no period
 - Separate conversation exchanges with ----
 
-## Step 4: Push to Remote
-After committing, push the branch to the remote repository:
-- If the branch doesn't have an upstream, use `git push -u origin <branch-name>`
-- If the branch already has an upstream, use `git push`
+## Step 4: Rebase onto Base Branch to Detect and Resolve Conflicts
+Before pushing, rebase onto the latest base branch to ensure a clean merge:
 
-## Step 5: Create Pull Request
+1. Determine the base branch:
+   - Run `git symbolic-ref refs/remotes/origin/HEAD` to get the default branch (e.g., `origin/main`)
+   - Strip the `refs/remotes/origin/` prefix to get the branch name
+2. Fetch the latest state of the base branch:
+   - `git fetch origin <base-branch>`
+3. Rebase the current branch onto the base branch:
+   - `git rebase origin/<base-branch>`
+   - If rebase succeeds cleanly, proceed to the next step
+   - If conflicts are detected during rebase:
+     a. Read the conflicting files and understand the intent of both sides
+     b. Edit files to resolve conflicts
+     c. `git add <resolved-files>`
+     d. `git rebase --continue`
+     e. Repeat for any subsequent conflicts in the rebase
+     f. After successful rebase, inform the user which files had conflicts and how they were resolved
+
+## Step 5: Push to Remote
+After committing and verifying no conflicts, push the branch to the remote repository:
+- If the branch doesn't have an upstream, use `git push -u origin <branch-name>`
+- If the branch already has an upstream, use `git push` (if rebase was performed, use `git push --force-with-lease`)
+
+## Step 6: Create Pull Request
 Create a Pull Request using `gh pr create`:
 
 1. First, check if a PULL_REQUEST_TEMPLATE exists in the repository:
@@ -122,3 +141,23 @@ EOF
 ```
 
 5. After creating the PR, output the PR URL so the user can access it.
+
+## Step 7: Verify CI Status
+After creating the PR, monitor CI checks and fix failures:
+
+1. Wait briefly for CI to start, then check status:
+   - `gh pr checks <pr-number> --watch` to watch CI progress (timeout after 10 minutes)
+   - Alternatively, use `gh run list --branch <branch-name> --limit 5` to find the run, then `gh run view <run-id>` for details
+2. If all checks pass, report success and finish
+3. If any check fails:
+   a. Identify the failed check(s) from the output
+   b. Get detailed logs: `gh run view <run-id> --log-failed`
+   c. Analyze the failure:
+      - Build errors: read the error messages and fix the source code
+      - Test failures: identify which tests failed, read the test and source code, and fix
+      - Lint errors: run the linter locally, fix the issues
+      - Other failures: investigate the logs and determine the root cause
+   d. After fixing, create a new commit (following Step 2-3 format) with a message like `fix(ci): <description of fix>`
+   e. Push the fix with `git push`
+   f. Go back to sub-step 1 to re-check CI status
+   g. Repeat up to 3 times. If CI still fails after 3 attempts, report the remaining failures to the user with detailed context

--- a/dot_codex/skills/commit-push-pr/SKILL.md
+++ b/dot_codex/skills/commit-push-pr/SKILL.md
@@ -27,10 +27,17 @@ description: Create a git commit, push a branch, and open a Pull Request with gh
      - Optional footer(s)
    - Use `feat|fix|docs|style|refactor|test|chore|ci|build|perf` as needed.
    - Keep description present tense, lowercase, under 50 chars, no period.
-5. Push the branch.
+5. Rebase onto the base branch to detect and resolve conflicts.
+   - Determine the base branch via `git symbolic-ref refs/remotes/origin/HEAD`.
+   - `git fetch origin <base-branch>`.
+   - `git rebase origin/<base-branch>`.
+     - If clean: proceed.
+     - If conflicts: resolve them, `git add <files>`, `git rebase --continue`. Repeat for each conflicting commit.
+     - Report which files had conflicts and how they were resolved.
+6. Push the branch.
    - If no upstream: `git push -u origin <branch-name>`.
-   - Otherwise: `git push`.
-6. Create a PR with `gh pr create`.
+   - Otherwise: `git push` (use `git push --force-with-lease` if rebase was performed).
+7. Create a PR with `gh pr create`.
    - Look for PR templates in `.github/PULL_REQUEST_TEMPLATE.md`, `.github/PULL_REQUEST_TEMPLATE/`, or `docs/PULL_REQUEST_TEMPLATE.md`.
    - If no template, use a language-appropriate default template.
    - Use a HEREDOC body:
@@ -40,7 +47,16 @@ description: Create a git commit, push a branch, and open a Pull Request with gh
      EOF
      )"
      ```
-7. Output the PR URL.
+8. Output the PR URL.
+9. Verify CI status.
+   - `gh pr checks <pr-number> --watch` (timeout 10 minutes), or `gh run list --branch <branch> --limit 5` + `gh run view <run-id>`.
+   - If all checks pass: report success.
+   - If any check fails:
+     a. `gh run view <run-id> --log-failed` to get detailed logs.
+     b. Analyze and fix the failure (build errors, test failures, lint errors, etc.).
+     c. Create a new commit (`fix(ci): <description>`), push.
+     d. Re-check CI. Repeat up to 3 times.
+     e. If still failing after 3 attempts, report remaining failures to the user.
 
 ## Default PR templates
 


### PR DESCRIPTION
## Summary
- Add rebase-based conflict detection before pushing to ensure clean merges
- Add CI status verification after PR creation with automatic failure investigation and fix retry (up to 3 attempts)

## Changes
- `dot_claude/commands/commit-push-pr.md`:
  - Added Step 4: Rebase onto base branch to detect and resolve conflicts
  - Renamed Steps 4-5 to Steps 5-6
  - Added Step 7: Verify CI status with auto-retry logic
  - Added `git fetch`, `git rebase`, `gh pr checks`, `gh run view/watch/list` to allowed-tools
- `dot_codex/skills/commit-push-pr/SKILL.md`:
  - Added Step 5: Rebase onto base branch for conflict detection
  - Renamed Steps 5-7 to Steps 6-8
  - Added Step 9: CI verification with retry logic

## Test Plan
- Run `/commit-push-pr` on a branch with known conflicts against main to verify rebase flow
- Run `/commit-push-pr` on a repo with CI configured to verify check monitoring

## Notes
- Uses `git rebase` instead of `git merge` for conflict detection per user preference
- `git push` and `git merge` are intentionally excluded from allowed-tools to require user confirmation
- CI retry is capped at 3 attempts to avoid infinite loops