### PR TITLE
feat(rules): add GitHub Actions workflow rules for all AI assistants

### DIFF
--- a/dot_claude/rules/github-actions.md
+++ b/dot_claude/rules/github-actions.md
@@ -1,0 +1,23 @@
+---
+path: "**/.github/workflows/*.{yml,yaml}"
+---
+
+# GitHub Actions Workflow Style
+
+- workflow ファイルを作成・編集した後は、必ず `actionlint` を実行して構文エラーがないことを確認すること
+- `actionlint` 実行後、`pinact run -u` を実行して全ての action 参照を SHA ピンにすること（タグ参照のまま残さない）
+- 新しいリポジトリに CI を構築する場合は、actionlint を実行する job を必ず含めること。以下のパターンを使う:
+
+```yaml
+actionlint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@vX
+    - name: Install actionlint
+      run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+    - name: Run actionlint
+      run: ./actionlint
+```
+
+- action のバージョンは `@vX.Y.Z` のようなタグではなく、SHA ハッシュで固定する（`pinact run -u` が自動で行う）
+- `pinact run -u` はタグをSHAに変換し、コメントで元のタグバージョンを付記する

--- a/dot_codex/AGENTS.md
+++ b/dot_codex/AGENTS.md
@@ -7,6 +7,25 @@
 - git commit 時はまず `git commit -S` で signed commit を試みる。失敗した場合は `git -c commit.gpgsign=false commit` でフォールバックする
 - AGENTS.md を新規作成した場合は、必ずユーザーにレビューしてもらってからコミットする
 
+# GitHub Actions Workflow
+
+- workflow ファイル（`.github/workflows/*.yml`, `.github/workflows/*.yaml`）を作成・編集した後は、必ず `actionlint` を実行して構文エラーがないことを確認する
+- `actionlint` 実行後、`pinact run -u` を実行して全ての action 参照を SHA ピンにする（タグ参照のまま残さない）
+- 新しいリポジトリに CI を構築する場合は、actionlint を実行する job を必ず含める。パターン:
+
+```yaml
+actionlint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@vX
+    - name: Install actionlint
+      run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+    - name: Run actionlint
+      run: ./actionlint
+```
+
+- action のバージョンはタグではなく SHA ハッシュで固定する（`pinact run -u` が自動で行う）
+
 # 口調: ずんだもん
 
 - 一人称は「ぼく」

--- a/dot_opencode/AGENTS.md
+++ b/dot_opencode/AGENTS.md
@@ -5,3 +5,22 @@
 - ソースコード編集後は、その言語のフォーマッタを実行すること（Go: `go fmt`, Deno: `deno fmt` 等）
 - テストは必ず書くこと。TDD の Red-Green-Refactor サイクルに従い、まず失敗するテストを書き、通る最小限のコードを書き、リファクタリングする
 - git commit 時はまず `git commit -S` で signed commit を試みること。失敗した場合は `git -c commit.gpgsign=false commit` でフォールバックする
+
+# GitHub Actions Workflow
+
+- workflow ファイル（`.github/workflows/*.yml`, `.github/workflows/*.yaml`）を作成・編集した後は、必ず `actionlint` を実行して構文エラーがないことを確認すること
+- `actionlint` 実行後、`pinact run -u` を実行して全ての action 参照を SHA ピンにすること（タグ参照のまま残さない）
+- 新しいリポジトリに CI を構築する場合は、actionlint を実行する job を必ず含めること。パターン:
+
+```yaml
+actionlint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@vX
+    - name: Install actionlint
+      run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+    - name: Run actionlint
+      run: ./actionlint
+```
+
+- action のバージョンはタグではなく SHA ハッシュで固定する（`pinact run -u` が自動で行う）


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow rules to Claude, Codex, and OpenCode configurations
- Rules enforce `actionlint` validation and `pinact run -u` SHA pinning after editing workflow files
- Include actionlint job template for new repository CI setup

## Changes
- **`dot_claude/rules/github-actions.md`** (new): Path-scoped rule (`**/.github/workflows/*.{yml,yaml}`) that auto-activates when editing workflow files
- **`dot_codex/AGENTS.md`**: Added `# GitHub Actions Workflow` section with identical rules
- **`dot_opencode/AGENTS.md`**: Added `# GitHub Actions Workflow` section with identical rules

## Test Plan
- [ ] Verify Claude rule loads when editing `.github/workflows/*.yaml` files
- [ ] Verify Codex and OpenCode AGENTS.md sections are correctly formatted
- [ ] Confirm actionlint job template is valid YAML

## Notes
Claude uses path-scoped rules (frontmatter `path:` field) for automatic activation, while Codex and OpenCode use AGENTS.md sections that are always loaded.