### PR TITLE
fix(poker): add dark theme support to journal template

### DIFF
--- a/dot_claude/skills/poker-hand-review/references/journal-template.html
+++ b/dot_claude/skills/poker-hand-review/references/journal-template.html
@@ -5,43 +5,97 @@
   <title>{{title}}</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown.min.css">
   <style>
+    /* ===== CSS Custom Properties (Light) ===== */
+    :root {
+      --bg-primary: #ffffff;
+      --bg-secondary: #f6f8fa;
+      --border-color: #d0d7de;
+      --text-primary: #1f2328;
+      --text-secondary: #656d76;
+      --link-color: #0969da;
+
+      --accent-blue: #0969da;
+      --accent-green: #1a7f37;
+      --accent-yellow: #bf8700;
+      --accent-red: #cf222e;
+
+      --callout-math-bg: #f6f8fa;
+      --callout-exploit-bg: #fff8c5;
+      --callout-insight-bg: #dafbe1;
+      --callout-question-bg: #fff8c5;
+      --callout-danger-bg: #ffebe9;
+      --callout-info-bg: #ddf4ff;
+
+      color-scheme: light dark;
+    }
+
+    /* ===== CSS Custom Properties (Dark) ===== */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #0d1117;
+        --bg-secondary: #161b22;
+        --border-color: #30363d;
+        --text-primary: #e6edf3;
+        --text-secondary: #8b949e;
+        --link-color: #58a6ff;
+
+        --accent-blue: #58a6ff;
+        --accent-green: #3fb950;
+        --accent-yellow: #d29922;
+        --accent-red: #f85149;
+
+        --callout-math-bg: #161b22;
+        --callout-exploit-bg: #2d2000;
+        --callout-insight-bg: #0d2818;
+        --callout-question-bg: #2d2000;
+        --callout-danger-bg: #2d0709;
+        --callout-info-bg: #0c2d4a;
+      }
+    }
+
     /* ===== Layout ===== */
     body {
       max-width: 980px;
       margin: 0 auto;
       padding: 30px;
-      background: #fff;
+      background: var(--bg-primary);
+      color: var(--text-primary);
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
     }
-    .markdown-body { max-width: 100%; }
-    h1 { border-bottom: 1px solid #d0d7de; padding-bottom: 8px; }
-    h2 { border-bottom: 1px solid #d0d7de; padding-bottom: 6px; margin-top: 32px; }
+    .markdown-body {
+      max-width: 100%;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+    }
+    h1 { border-bottom: 1px solid var(--border-color); padding-bottom: 8px; }
+    h2 { border-bottom: 1px solid var(--border-color); padding-bottom: 6px; margin-top: 32px; }
+    a { color: var(--link-color); }
 
     /* ===== Common components ===== */
     table { border-collapse: collapse; width: 100%; margin: 12px 0; }
-    th, td { border: 1px solid #d0d7de; padding: 8px 12px; text-align: left; }
-    th { background: #f6f8fa; }
-    .screenshot { max-width: 100%; border: 1px solid #d0d7de; border-radius: 6px; margin: 12px 0; }
-    .source-link { font-size: 0.85em; color: #656d76; }
+    th, td { border: 1px solid var(--border-color); padding: 8px 12px; text-align: left; }
+    th { background: var(--bg-secondary); }
+    .screenshot { max-width: 100%; border: 1px solid var(--border-color); border-radius: 6px; margin: 12px 0; }
+    .source-link { font-size: 0.85em; color: var(--text-secondary); }
 
     /* ===== [review] Math / Assessment blocks ===== */
-    .math-block { background: #f6f8fa; border-left: 3px solid #0969da; padding: 12px 16px; margin: 12px 0; font-family: monospace; }
-    .assessment-good { border-left-color: #1a7f37; }
-    .assessment-warn { border-left-color: #bf8700; }
-    .assessment-bad  { border-left-color: #cf222e; }
+    .math-block { background: var(--callout-math-bg); border-left: 3px solid var(--accent-blue); padding: 12px 16px; margin: 12px 0; font-family: monospace; }
+    .assessment-good { border-left-color: var(--accent-green); }
+    .assessment-warn { border-left-color: var(--accent-yellow); }
+    .assessment-bad  { border-left-color: var(--accent-red); }
 
     /* ===== [review] Exploit quote ===== */
-    .exploit-quote { background: #fff8c5; border-left: 3px solid #bf8700; padding: 12px 16px; margin: 12px 0; }
+    .exploit-quote { background: var(--callout-exploit-bg); border-left: 3px solid var(--accent-yellow); padding: 12px 16px; margin: 12px 0; }
 
     /* ===== [study] Callout blocks ===== */
-    .insight { background: #dafbe1; border-left: 3px solid #1a7f37; padding: 12px 16px; margin: 12px 0; }
-    .question { background: #fff8c5; border-left: 3px solid #bf8700; padding: 12px 16px; margin: 12px 0; }
-    .exploit { background: #ffebe9; border-left: 3px solid #cf222e; padding: 12px 16px; margin: 12px 0; }
-    .future-topic { background: #ddf4ff; border-left: 3px solid #0969da; padding: 12px 16px; margin: 12px 0; }
+    .insight { background: var(--callout-insight-bg); border-left: 3px solid var(--accent-green); padding: 12px 16px; margin: 12px 0; }
+    .question { background: var(--callout-question-bg); border-left: 3px solid var(--accent-yellow); padding: 12px 16px; margin: 12px 0; }
+    .exploit { background: var(--callout-danger-bg); border-left: 3px solid var(--accent-red); padding: 12px 16px; margin: 12px 0; }
+    .future-topic { background: var(--callout-info-bg); border-left: 3px solid var(--accent-blue); padding: 12px 16px; margin: 12px 0; }
 
     /* ===== Print ===== */
     @media print {
-      body { padding: 0; }
+      body { padding: 0; background: #fff; color: #000; }
       .page-break { page-break-before: always; }
     }
   </style>


### PR DESCRIPTION
## Summary
- Add `prefers-color-scheme: dark` support to the poker hand review journal HTML template
- Replace all hardcoded color values with CSS custom properties
- Dark theme uses GitHub Dark palette for consistency

## Changes
- Introduce CSS custom properties (`:root` variables) for all colors
- Add `@media (prefers-color-scheme: dark)` block with GitHub Dark-compatible colors
- Add `color-scheme: light dark` declaration for native browser element theming
- Force white background / black text for print media
- All callout blocks (math, insight, question, exploit, future-topic) now use dark-safe backgrounds

## Test Plan
- Open a generated journal HTML in a browser with dark mode enabled
- Verify no color breakage (e.g., white background with yellow text)
- Verify light mode appearance is unchanged
- Verify print preview uses white background

## Notes
- Dark palette sourced from GitHub's Primer color system (`#0d1117`, `#161b22`, `#30363d`, etc.)
- Callout backgrounds use deep, muted tones of the same hue to maintain semantic meaning