### PR TITLE
feat: add Ghostty terminal configuration

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,21 @@
+# Theme
+theme = Iceberg Dark
+background-opacity = 0.9
+
+# Font
+font-family = JetBrains Mono
+font-family = Biz UDGothic
+font-size = 17
+
+# Scrollback
+scrollback-limit = 1000
+
+# Terminal
+term = xterm-256color
+
+# Quick Terminal (Quake mode)
+keybind = global:ctrl+s=toggle_quick_terminal
+quick-terminal-position = top
+quick-terminal-screen = main
+quick-terminal-animation-duration = 0
+quick-terminal-size = 100%

--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -17,7 +17,7 @@ do
   fi
 done
 
-DOT_CONFIG_DIRS=(mdp)
+DOT_CONFIG_DIRS=(mdp ghostty)
 
 mkdir -p "$HOME/.config"
 


### PR DESCRIPTION
## Summary
- Ghostty設定ファイル (`ghostty/config`) を追加
  - テーマ: Iceberg Dark (背景透過0.9)
  - フォント: JetBrains Mono + Biz UDGothic (size 17)
  - Quick Terminal (Ctrl+S でトグル、画面上部、アニメーションなし)
- `scripts/setup-symlinks.sh` の `DOT_CONFIG_DIRS` に `ghostty` を追加し、`~/.config/ghostty` へのsymlinkを作成

## Test plan
- [ ] `setup.sh` を実行して `~/.config/ghostty` が正しくsymlinkされることを確認
- [ ] Ghosttyを起動して設定が反映されることを確認