### PR TITLE
feat: add ~/.local/bin to PATH and enable skipAutoPermissionPrompt

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -148,5 +148,7 @@ function peco-src () {
 zle -N peco-src
 bindkey '^|' peco-src
 
+export PATH="$HOME/.local/bin:$PATH"
+
 ## local固有設定
 [ -f ~/.config/zsh.local ] && source ~/.config/zsh.local

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -79,5 +79,6 @@
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
   "showClearContextOnPlanAccept": true,
-  "plansDirectory": "./plans"
+  "plansDirectory": "./plans",
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- `.zshrc` に `$HOME/.local/bin` を `PATH` の先頭に追加
- `dot_claude/settings.json` に `skipAutoPermissionPrompt: true` を追加

## Test plan
- [ ] `source ~/.zshrc` 後に `echo $PATH` で `~/.local/bin` が含まれることを確認
- [ ] Claude Code の起動時に自動パーミッションプロンプトがスキップされることを確認