### PR TITLE
feat(ghostty,zsh): switch ghostty to Iceberg Light and bold the prompt

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -45,7 +45,7 @@ function git_branch_name() {
 
 # 一般ユーザ時
  # tmp_prompt="%{${fg[cyan]}%}%n%# %{${reset_color}%}"
- tmp_prompt="%{${fg[green]}%}[%~]%{${reset_color}%}%{${fg[yellow]}%}\$(git_branch_name)%{${reset_color}%} %{${fg[cyan]}%}whywaita%# %{${reset_color}%}"
+ tmp_prompt="%B%{${fg[green]}%}[%~]%f%{${fg[yellow]}%}\$(git_branch_name)%f %{${fg[cyan]}%}whywaita%# %f%b"
  tmp_prompt2="%{${fg[cyan]}%}%_> %{${reset_color}%}"
  tmp_rprompt=""
  tmp_sprompt="%{${fg[yellow]}%}%r is correct? [Yes, No, Abort, Edit]:%{${reset_color}%}"

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,5 +1,5 @@
 # Theme
-theme = Iceberg Dark
+theme = Iceberg Light
 background-opacity = 0.9
 
 # Font


### PR DESCRIPTION
## Summary
- Switch ghostty theme from `Iceberg Dark` to `Iceberg Light` for daytime use.
- Make the zsh prompt bold so colored segments stay legible on a light background.

## Changes
- `ghostty/config`: `theme = Iceberg Dark` → `Iceberg Light` (opacity unchanged).
- `.zshrc`: wrap the user prompt with `%B`/`%b` and replace `${reset_color}` with `%f`. `${reset_color}` emits SGR 0 which also clears bold, so reset to color-only (`%f`) keeps bold applied across `[%~]`, the git branch, and the user segment.

## Test Plan
- Reload ghostty (`Cmd+Shift+,`); confirm the light theme renders.
- `source ~/.zshrc`; confirm path / branch / user are all bold and colors are preserved.

## Notes
- root-user branch (line 55) already wraps with `%B%U…%u%b`, so no change needed there.
- `PROMPT2` / `SPROMPT` are intentionally left as-is for now.