### PR TITLE
"feat(claude): add PreCompact hook for auto checkpoint before compaction"

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -25,6 +25,17 @@
   },
   "model": "opus[1m]",
   "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mkdir -p ~/.claude/compact-memory && echo \"# Checkpoint $(date '+%Y-%m-%d %H:%M')\" > ~/.claude/compact-memory/checkpoint-$(date '+%Y%m%d-%H%M%S').md && echo '' >> ~/.claude/compact-memory/checkpoint-$(date '+%Y%m%d-%H%M%S').md && echo 'PreCompact hook fired. Key decisions, file changes, and next steps should be summarized by the session.' >> ~/.claude/compact-memory/checkpoint-$(date '+%Y%m%d-%H%M%S').md"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "",


### PR DESCRIPTION
"When compact occurs during Claude Code 1M context usage, each instance automatically creates a checkpoint.

## Changes

Added a `PreCompact` hook to `dot_claude/settings.json` that generates a checkpoint marker file in `~/.claude/compact-memory/` right before compaction.

## Why hook instead of watcher script

- Supports running multiple Claude Code instances in the same tmux session
- `PreCompact` hook fires independently per instance, so no external watcher process is needed
- No dependency on tmux capture-pane/send-keys, avoiding instance collision issues"