### PR TITLE
feat(claude): add tmux pane color change on permission prompt

### DIFF
--- a/dot_claude/scripts/tmux-pane-color-on-permission.sh
+++ b/dot_claude/scripts/tmux-pane-color-on-permission.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ -n "${TMUX_PANE:-}" ] || exit 0
+
+payload=$(cat)
+message=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+
+case "$message" in
+  *permission*|*許可*)
+    tmux set -p -t "$TMUX_PANE" window-style 'bg=colour159'
+    tmux set -p -t "$TMUX_PANE" window-active-style 'bg=colour159'
+    ;;
+esac

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -32,6 +32,43 @@
           {
             "type": "command",
             "command": "osascript -e 'display notification \"Claude Codeが許可を求めています\" with title \"Claude Code\" subtitle \"確認待ち\" sound name \"Glass\"'"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/dotfiles/dot_claude/scripts/tmux-pane-color-on-permission.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set -p -u -t \"$TMUX_PANE\" window-style && tmux set -p -u -t \"$TMUX_PANE\" window-active-style || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set -p -u -t \"$TMUX_PANE\" window-style && tmux set -p -u -t \"$TMUX_PANE\" window-active-style || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set -p -u -t \"$TMUX_PANE\" window-style && tmux set -p -u -t \"$TMUX_PANE\" window-active-style || true"
           }
         ]
       }
@@ -43,6 +80,10 @@
           {
             "type": "command",
             "command": "osascript -e 'display notification \"タスクが完了しました\" with title \"Claude Code\" subtitle \"処理終了\" sound name \"Hero\"'"
+          },
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set -p -u -t \"$TMUX_PANE\" window-style && tmux set -p -u -t \"$TMUX_PANE\" window-active-style || true"
           }
         ]
       }
@@ -80,5 +121,6 @@
   "effortLevel": "high",
   "showClearContextOnPlanAccept": true,
   "plansDirectory": "./plans",
+  "theme": "auto",
   "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- Claude Codeが許可待ち（Notification hook）の際に、tmuxペインの背景色を青（colour159）に変更するスクリプトとhooksを追加
- ユーザー操作再開時（UserPromptSubmit, PreToolUse, PostToolUse, Stop）に背景色を元に戻す
- theme設定を `auto` に変更

## 仕組み
- `Notification` hook: `tmux-pane-color-on-permission.sh` を実行し、通知メッセージに "permission" または "許可" が含まれる場合にペイン背景を青に変更
- `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` hook: `tmux set -p -u` でペインスタイルをリセット
- tmux外で実行している場合は何もしない（`$TMUX_PANE` チェック）

## Test plan
- [ ] tmux内でClaude Codeを起動し、許可待ちが発生した際にペインが青くなることを確認
- [ ] 許可を与えた後、ペインの色が元に戻ることを確認
- [ ] tmux外で実行した場合にエラーが出ないことを確認