### PR TITLE
fix(git): fix indentation in gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -15,6 +15,6 @@
 [init]
   defaultBranch = main
 [url "ssh://git@github.com/"]
-  insteadOf = https://github.com/
+    insteadOf = https://github.com/
 [wt]
 	basedir = .worktrees


### PR DESCRIPTION
## Summary
- Fix indentation of `insteadOf` in `.gitconfig` (2 spaces -> 4 spaces)

## Test plan
- [ ] Verify git URL rewriting works correctly